### PR TITLE
Thêm GitHub Actions cho MineVNLib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,5 @@
 name: Build
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,12 @@
 name: Build
-on: push
+on:
+  push:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,14 @@ jobs:
         run: |
           chmod +x ./gradlew
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
-          echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==3')"
         id: env
       - name: Build MineVNLib
         run: |
           ./gradlew assemble
+          echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==3')"
           mkdir -p target
           cp ./minevnlib-plugin/build/libs/MineVNLib.jar ./target/MineVNLib.jar
+        id: plugin
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.3.1
         with:
@@ -37,7 +38,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ steps.env.outputs.version }}-${{ steps.env.outputs.hash }}
+          automatic_release_tag: ${{ steps.plugin.outputs.version }}-${{ steps.env.outputs.hash }}
           prerelease: true
-          title: "MineVNLib - ${{ steps.env.outputs.version }}-${{ steps.env.outputs.hash }}"
+          title: "MineVNLib - ${{ steps.plugin.outputs.version }}-${{ steps.env.outputs.hash }}"
           files: ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ jobs:
           path: ./target/MineVNLib.jar
       - name: Release
         uses: "marvinpinto/action-automatic-releases@latest"
-          with:
-            repo_token: "${{ secrets.GITHUB_TOKEN }}"
-            automatic_release_tag: "${GITHUB_SHA}"
-            prerelease: true
-            title: "MineVNLib - ${GITHUB_SHA}"
-            files: ./target/MineVNLib.jar
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${GITHUB_SHA}"
+          prerelease: true
+          title: "MineVNLib - ${GITHUB_SHA}"
+          files: ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - "master"
 
 jobs:
   build:
+    if: (github.event_name == 'pull_request' && github.event.action == 'labeled') || github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "${GITHUB_SHA}"
+          automatic_release_tag: ${{ github.sha }}
           prerelease: true
-          title: "MineVNLib - ${GITHUB_SHA}"
+          title: "MineVNLib - ${{ github.sha }}"
           files: ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,11 @@ jobs:
       - name: Get commit sha
         run: |
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
-        id: version
+        id: git
+      - name: Get version
+        run: |
+          echo "::set-output name=version::$(awk '/version =/ {gsub("\"", "", $NF); print $NF}' build.gradle.kts | sed 's/[[:space:]]//g')"
+        id: mcversion
       - name: Build MineVNLib
         run: |
           chmod +x ./gradlew
@@ -31,7 +35,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ steps.version.outputs.hash }}
+          automatic_release_tag: ${{ steps.mcversion.outputs.version }}-${{ steps.git.outputs.hash }}
           prerelease: true
-          title: "MineVNLib - ${{ steps.version.outputs.hash }}"
+          title: "MineVNLib - ${{ steps.git.outputs.hash }}"
           files: ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,10 @@
 name: Build
 on:
-  push:
+  workflow_dispatch:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled
+  push:
+    branches:
+      - "master"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "gradle"
+      - name: Get version
+        run: |
+          echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
+        id: version
       - name: Build ML
         run: |
           chmod +x ./gradlew
@@ -30,7 +34,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ github.sha }}
+          automatic_release_tag: ${{ steps.version.outputs.hash }}
           prerelease: true
-          title: "MineVNLib - ${{ github.sha }}"
+          title: "MineVNLib - ${{ steps.version.outputs.hash }}"
           files: ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
         id: version
-      - name: Build ML
+      - name: Build MineVNLib
         run: |
           chmod +x ./gradlew
           ./gradlew assemble

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           cp ./minevnlib-plugin/build/libs/MineVNLib.jar ./target/MineVNLib.jar
       - name: Get version
         run: |
-          echo "::set-output name=version::$(./gradlew printVersion | grep "> Task :printVersion" | awk '{print $NF}')"
+          echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==2')"
         id: mcversion
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,17 +19,14 @@ jobs:
       - name: Get commit sha
         run: |
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
-        id: git
+          echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==3')"
+        id: env
       - name: Build MineVNLib
         run: |
           chmod +x ./gradlew
           ./gradlew assemble
           mkdir -p target
           cp ./minevnlib-plugin/build/libs/MineVNLib.jar ./target/MineVNLib.jar
-      - name: Get version
-        run: |
-          echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==2')"
-        id: mcversion
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.3.1
         with:
@@ -40,7 +37,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ steps.mcversion.outputs.version }}-${{ steps.git.outputs.hash }}
+          automatic_release_tag: ${{ steps.env.outputs.version }}-${{ steps.env.outputs.hash }}
           prerelease: true
-          title: "MineVNLib - ${{ steps.git.outputs.hash }}"
+          title: "MineVNLib - ${{ steps.env.outputs.version }}-${{ steps.env.outputs.hash }}"
           files: ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ jobs:
           cache: "gradle"
       - name: Get commit sha & plugin version
         run: |
+          chmod +x ./gradlew
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
           echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==3')"
         id: env
       - name: Build MineVNLib
         run: |
-          chmod +x ./gradlew
           ./gradlew assemble
           mkdir -p target
           cp ./minevnlib-plugin/build/libs/MineVNLib.jar ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v4.0.0
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: "gradle"
+      - name: Build ML
+        run: |
+          chmod +x ./gradlew
+          ./gradlew assemble
+          mkdir -p target
+          cp ./minevnlib-plugin/build/libs/MineVNLib.jar ./target/MineVNLib.jar
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: "MineVNLib"
+          path: ./target/MineVNLib.jar
+      - name: Release
+        uses: "marvinpinto/action-automatic-releases@latest"
+          with:
+            repo_token: "${{ secrets.GITHUB_TOKEN }}"
+            automatic_release_tag: "${GITHUB_SHA}"
+            prerelease: true
+            title: "MineVNLib - ${GITHUB_SHA}"
+            files: ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,16 @@ jobs:
         run: |
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
         id: git
-      - name: Get version
-        run: |
-          echo "::set-output name=version::$(awk '/version =/ {gsub("\"", "", $NF); print $NF}' build.gradle.kts | sed 's/[[:space:]]//g')"
-        id: mcversion
       - name: Build MineVNLib
         run: |
           chmod +x ./gradlew
           ./gradlew assemble
           mkdir -p target
           cp ./minevnlib-plugin/build/libs/MineVNLib.jar ./target/MineVNLib.jar
+      - name: Get version
+        run: |
+          echo "::set-output name=version::$(./gradlew printVersion | grep "> Task :printVersion" | awk '{print $NF}')"
+        id: mcversion
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.3.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "gradle"
-      - name: Get version
+      - name: Get commit sha
         run: |
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
         id: version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,17 +16,14 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "gradle"
-      - name: Get commit sha
+      - name: Build MineVNLib & get plugin informations
         run: |
           chmod +x ./gradlew
-          echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
-        id: env
-      - name: Build MineVNLib & get plugin version
-        run: |
           ./gradlew assemble
-          echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==3')"
           mkdir -p target
           cp ./minevnlib-plugin/build/libs/MineVNLib.jar ./target/MineVNLib.jar
+          echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
+          echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==3')"
         id: plugin
       - name: Upload build artifact
         uses: actions/upload-artifact@v4.3.1
@@ -38,7 +35,7 @@ jobs:
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: ${{ steps.plugin.outputs.version }}-${{ steps.env.outputs.hash }}
+          automatic_release_tag: ${{ steps.plugin.outputs.version }}-${{ steps.plugin.outputs.hash }}
           prerelease: true
-          title: "MineVNLib - ${{ steps.plugin.outputs.version }}-${{ steps.env.outputs.hash }}"
+          title: "MineVNLib - ${{ steps.plugin.outputs.version }}-${{ steps.plugin.outputs.hash }}"
           files: ./target/MineVNLib.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           name: "MineVNLib"
           path: ./target/MineVNLib.jar
       - name: Release
+        if: github.ref_name == 'master'
         uses: "marvinpinto/action-automatic-releases@latest"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,12 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "gradle"
-      - name: Get commit sha & plugin version
+      - name: Get commit sha
         run: |
           chmod +x ./gradlew
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
         id: env
-      - name: Build MineVNLib
+      - name: Build MineVNLib & get plugin version
         run: |
           ./gradlew assemble
           echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==3')"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "gradle"
-      - name: Get commit sha
+      - name: Get commit sha & plugin version
         run: |
           echo "::set-output name=hash::$(git rev-parse --short ${{ github.sha }})"
           echo "::set-output name=version::$(./gradlew :minevnlib-plugin:printVersion | awk 'NR==3')"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
 
 plugins {
     `java-library`
@@ -35,6 +37,12 @@ allprojects {
     tasks {
         test {
             useJUnitPlatform()
+        }
+    }
+
+    task("printVersion") {
+        doLast {
+            println("${project.version}")
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,4 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.TaskAction
 
 plugins {
     `java-library`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,12 +38,13 @@ allprojects {
         test {
             useJUnitPlatform()
         }
-    }
 
-    task("printVersion") {
-        doLast {
-            println("${project.version}")
+        register("printVersion") {
+            doLast {
+                println("${project.version}")
+            }
         }
+  
     }
 
     java {


### PR DESCRIPTION
Khi có push lên branch `master`, action sẽ khởi chạy với cấu hình từ `./github/workflows/build.yml`. Các bước bao gồm build MineVNLib, sau đó tạo pre-release với version là commit sha trigger action đó (rút gọn)

Release chỉ tạo trên master

Demo 1 action mẫu kèm artifact: https://github.com/minhh2792/minevn-library/actions/runs/8081809122

## Test case:
- [x] Build ML
- [x] Tạo pre-release

