### PR TITLE
Tối ưu hóa DataAccess

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = "net.minevn"
-    version = "1.0.5"
+    version = "1.0.6"
 
     apply(plugin = "java")
     apply(plugin = "org.jetbrains.kotlin.jvm")

--- a/minevnlib-bukkit/src/main/java/net/minevn/libs/bukkit/MineVNPlugin.kt
+++ b/minevnlib-bukkit/src/main/java/net/minevn/libs/bukkit/MineVNPlugin.kt
@@ -22,7 +22,7 @@ abstract class MineVNPlugin : JavaPlugin() {
         private set(value) {
             field?.disconnect()
             field = value
-            daoPool = if (value != null) DataAccessPool(value) else null
+            daoPool = if (value != null) DataAccessPool(value, classLoader) else null
         }
 
     /**

--- a/minevnlib-bukkit/src/main/resources/plugin.yml
+++ b/minevnlib-bukkit/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: MineVNLib
 author: MineVN
 main: net.minevn.libs.bukkit.MineVNLib
-version: 1.0.5
+version: 1.0.6
 softdepend: [eco]

--- a/minevnlib-master/src/main/java/net/minevn/libs/db/DataAccess.kt
+++ b/minevnlib-master/src/main/java/net/minevn/libs/db/DataAccess.kt
@@ -60,15 +60,16 @@ abstract class DataAccess {
         fetch { generateSequence { if (next()) action() else null }.toList() }
 }
 
-class DataAccessPool(private val databaseConnection: DatabasePool) {
+class DataAccessPool(private val databaseConnection: DatabasePool, val loader: ClassLoader) {
     private var instanceList = mutableMapOf<KClass<out DataAccess>, DataAccess>()
 
+    @Synchronized
     fun <T : DataAccess> getInstance(type: KClass<T>): T {
         val dbType = databaseConnection.getTypeName()
         var instance = instanceList[type]
         if (instance == null) {
             val basePackage = type.java.`package`.name
-            val daoClass = Class.forName("$basePackage.$dbType.${type.simpleName}Impl")
+            val daoClass = Class.forName("$basePackage.$dbType.${type.simpleName}Impl", true, loader)
             instance = type.cast(daoClass.getDeclaredConstructor().newInstance())
             instance.dbPool = databaseConnection
             instanceList[type] = instance


### PR DESCRIPTION
## Nội dung
Nguyên nhân và cách khắc phục
- Các class DAO có khả năng bị khởi tạo nhiều lần do không thread safe: Điều chỉnh hàm `DataAccessPool.getIntance` thành synchronized
- Không thể reload DotMan do classloader bị sai khi gọi hàm `Class.forName`: Truyền thêm classLoader của Plugin

## Test
- [x] Class DAO không còn bị khởi tạo nhiều lần (xác nhận qua debug logs)
- [x] Có thể reload DotMan khi server đang chạy