### PR TITLE
Đổi sang repo của aikar để build được module bungeecord

### DIFF
--- a/minevnlib-bungee/build.gradle.kts
+++ b/minevnlib-bungee/build.gradle.kts
@@ -1,5 +1,5 @@
 repositories {
-    maven("https://oss.sonatype.org/content/repositories/snapshots")
+    maven("https://repo.aikar.co/nexus/content/groups/aikar/")
 }
 
 dependencies {


### PR DESCRIPTION
Nguyên nhân: OSS-Sonatype EOS dẫn đến việc không thể build module bungeecord khi clone từ branch master hiện tại về

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build repository configuration for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->