### PR TITLE
Support tối thiểu phiên bản Java 17 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - master
 
 concurrency:
   group: build-${{ github.ref }}
@@ -10,7 +12,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v5.0.0
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 17
           cache: "gradle"
       - name: Build MineVNLib & get plugin informations
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     `java-library`
     kotlin("jvm") version "2.3.21"
@@ -48,15 +46,9 @@ allprojects {
   
     }
 
-    java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+    kotlin {
+        jvmToolchain(17)
     }
-    tasks.withType<JavaCompile>().configureEach {
-        options.release.set(8)
-    }
-
-    kotlin.compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 
     configurations {
         testImplementation.get().extendsFrom(compileOnly.get())


### PR DESCRIPTION
# Plugin sẽ yêu cầu cần có Java 17 để chạy.

**Java 8 bị drop:**
- Không tương thích với gradle mới
- Minecraft đã drop java 8 từ lâu, kể cả các phiên bản fork khỉ đột như 1.8 cũng đều đã sử dụng modern java như 11, 17..

**Thay đổi:**
- Cập nhật github actions để build bằng java 17
- Sửa build script gradle