### PR TITLE
Downgrade H2 về 2.1.214

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
 
     ignore:
       - dependency-name: "net.md-5:bungeecord-api"
-      - dependency-name: "com.h2database:h2:2.1.214"
+      - dependency-name: "com.h2database:h2"
 
     commit-message:
       prefix: "libs"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
 
     ignore:
       - dependency-name: "net.md-5:bungeecord-api"
+      - dependency-name: "com.h2database:h2:2.1.214"
 
     commit-message:
       prefix: "libs"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 allprojects {
     group = "net.minevn"
-    version = "26.1"
+    version = "26.1.1"
 
     apply(plugin = "java")
     apply(plugin = "org.jetbrains.kotlin.jvm")
@@ -18,7 +18,7 @@ allprojects {
     dependencies {
         // database
         implementation("com.zaxxer:HikariCP:7.0.2")
-        implementation("com.h2database:h2:2.4.240")
+        implementation("com.h2database:h2:2.1.214")
         implementation("org.mariadb.jdbc:mariadb-java-client:3.5.8") { exclude("*") }
 
         // ohthers


### PR DESCRIPTION
H2 phiên bản mới không thể đọc H2 phiên bản cũ.
Bump version lên 26.1.1

```
[14:15:43 ERROR]: [DotMan] Could not connect to the database
org.h2.jdbc.JdbcSQLNonTransientConnectionException: Unsupported database file version or invalid file header in file "/home/container/plugins/DotMan/dotman.mv.db" [90048-240]
        at MineVNLib.jar//org.h2.message.DbException.getJdbcSQLException(DbException.java:690) ~[?:?]
        at MineVNLib.jar//org.h2.message.DbException.getJdbcSQLException(DbException.java:489) ~[?:?]
        at MineVNLib.jar//org.h2.message.DbException.get(DbException.java:212) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.db.Store.convertMVStoreException(Store.java:158) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.db.Store.<init>(Store.java:142) ~[?:?]
        at MineVNLib.jar//org.h2.engine.Database.<init>(Database.java:328) ~[?:?]
        at MineVNLib.jar//org.h2.engine.Engine.openSession(Engine.java:92) ~[?:?]
        at MineVNLib.jar//org.h2.engine.Engine.openSession(Engine.java:222) ~[?:?]
        at MineVNLib.jar//org.h2.engine.Engine.createSession(Engine.java:201) ~[?:?]
        at MineVNLib.jar//org.h2.engine.SessionRemote.connectEmbeddedOrServer(SessionRemote.java:350) ~[?:?]
        at MineVNLib.jar//org.h2.jdbc.JdbcConnection.<init>(JdbcConnection.java:124) ~[?:?]
        at MineVNLib.jar//org.h2.jdbcx.JdbcDataSource.getConnection(JdbcDataSource.java:172) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.PoolBase.newConnection(PoolBase.java:373) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:210) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:488) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.HikariPool.checkFailFast(HikariPool.java:576) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.HikariPool.<init>(HikariPool.java:97) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.HikariDataSource.getConnection(HikariDataSource.java:111) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.db.pool.types.H2DBP.<init>(H2DBP.kt:28) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.bukkit.MineVNPlugin.initDatabase(MineVNPlugin.kt:77) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.bukkit.MineVNPlugin.initDatabase$default(MineVNPlugin.kt:56) ~[?:?]
        at DotMan-26.3-pre.jar//net.minevn.dotman.DotMan.reload(AntiDecompiler:106) ~[?:?]
        at DotMan-26.3-pre.jar//net.minevn.dotman.DotMan.onEnable(AntiDecompiler:74) ~[?:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279) ~[canvas-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:207) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[canvas-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:651) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:608) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at net.minecraft.server.MinecraftServer.initPostWorld(MinecraftServer.java:646) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:402) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1282) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:414) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: org.h2.mvstore.MVStoreException: The write format 2 is smaller than the supported format 3 [2.4.240/5]
        at MineVNLib.jar//org.h2.mvstore.DataUtils.newMVStoreException(DataUtils.java:996) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.FileStore.getUnsupportedWriteFormatException(FileStore.java:946) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.FileStore.processCommonHeaderAttributes(FileStore.java:548) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.RandomAccessStore.readStoreHeader(RandomAccessStore.java:227) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.FileStore.start(FileStore.java:919) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.MVStore.<init>(MVStore.java:294) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.MVStore$Builder.open(MVStore.java:2164) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.db.Store.<init>(Store.java:133) ~[?:?]
        ... 29 more
[14:15:43 ERROR]: Error occurred while enabling DotMan v26.3-premium (Is it up to date?)
org.h2.jdbc.JdbcSQLNonTransientConnectionException: Unsupported database file version or invalid file header in file "/home/container/plugins/DotMan/dotman.mv.db" [90048-240]
        at MineVNLib.jar//org.h2.message.DbException.getJdbcSQLException(DbException.java:690) ~[?:?]
        at MineVNLib.jar//org.h2.message.DbException.getJdbcSQLException(DbException.java:489) ~[?:?]
        at MineVNLib.jar//org.h2.message.DbException.get(DbException.java:212) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.db.Store.convertMVStoreException(Store.java:158) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.db.Store.<init>(Store.java:142) ~[?:?]
        at MineVNLib.jar//org.h2.engine.Database.<init>(Database.java:328) ~[?:?]
        at MineVNLib.jar//org.h2.engine.Engine.openSession(Engine.java:92) ~[?:?]
        at MineVNLib.jar//org.h2.engine.Engine.openSession(Engine.java:222) ~[?:?]
        at MineVNLib.jar//org.h2.engine.Engine.createSession(Engine.java:201) ~[?:?]
        at MineVNLib.jar//org.h2.engine.SessionRemote.connectEmbeddedOrServer(SessionRemote.java:350) ~[?:?]
        at MineVNLib.jar//org.h2.jdbc.JdbcConnection.<init>(JdbcConnection.java:124) ~[?:?]
        at MineVNLib.jar//org.h2.jdbcx.JdbcDataSource.getConnection(JdbcDataSource.java:172) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.PoolBase.newConnection(PoolBase.java:373) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:210) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:488) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.HikariPool.checkFailFast(HikariPool.java:576) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.pool.HikariPool.<init>(HikariPool.java:97) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.hikari.HikariDataSource.getConnection(HikariDataSource.java:111) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.db.pool.types.H2DBP.<init>(H2DBP.kt:28) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.bukkit.MineVNPlugin.initDatabase(MineVNPlugin.kt:77) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.bukkit.MineVNPlugin.initDatabase$default(MineVNPlugin.kt:56) ~[?:?]
        at DotMan-26.3-pre.jar//net.minevn.dotman.DotMan.reload(AntiDecompiler:106) ~[?:?]
        at DotMan-26.3-pre.jar//net.minevn.dotman.DotMan.onEnable(AntiDecompiler:74) ~[?:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279) ~[canvas-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:207) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[canvas-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:651) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:608) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at net.minecraft.server.MinecraftServer.initPostWorld(MinecraftServer.java:646) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:402) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1282) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:414) ~[canvas-1.21.11.jar:1.21.11--1-a5c43e0]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: org.h2.mvstore.MVStoreException: The write format 2 is smaller than the supported format 3 [2.4.240/5]
        at MineVNLib.jar//org.h2.mvstore.DataUtils.newMVStoreException(DataUtils.java:996) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.FileStore.getUnsupportedWriteFormatException(FileStore.java:946) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.FileStore.processCommonHeaderAttributes(FileStore.java:548) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.RandomAccessStore.readStoreHeader(RandomAccessStore.java:227) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.FileStore.start(FileStore.java:919) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.MVStore.<init>(MVStore.java:294) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.MVStore$Builder.open(MVStore.java:2164) ~[?:?]
        at MineVNLib.jar//org.h2.mvstore.db.Store.<init>(Store.java:133) ~[?:?]
        ... 29 more
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped project version to 26.1.1
  * Updated build configuration and dependency versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/minevn/minevn-library/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->