### PR TITLE
Patch AnvilGUI wrapper bytecode to compat with ASM <9.7 (PaperMC)

### DIFF
--- a/minevnlib-plugin/build.gradle.kts
+++ b/minevnlib-plugin/build.gradle.kts
@@ -1,4 +1,22 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("org.ow2.asm:asm:9.9.1")
+    }
+}
 
 plugins {
     id("com.gradleup.shadow") version "9.4.1"
@@ -62,6 +80,17 @@ tasks {
         relocate("com.cronutils", "net.minevn.libs.cronutils")
         exclude("META-INF/versions/21/org/h2/util/Utils21.class")
         exclude("META-INF/*.RSA", "META-INF/*.DSA", "META-INF/*.SF")
+
+        doLast {
+            rewriteClassVersion(
+                archiveFile.get().asFile,
+                setOf(
+                    "net/minevn/libs/anvilgui/version/Wrapper26_R1.class",
+                    $$"net/minevn/libs/anvilgui/version/Wrapper26_R1$AnvilContainer.class"
+                ),
+                Opcodes.V17
+            )
+        }
     }
 
     // shadow with kotlin
@@ -101,4 +130,51 @@ tasks {
     assemble {
         dependsOn(shadowJar, shadowNoKotlin, customCopy)
     }
+}
+
+fun rewriteClassVersion(jarFile: File, classEntries: Set<String>, targetVersion: Int) {
+    val tempFile = File.createTempFile(jarFile.nameWithoutExtension, ".jar", jarFile.parentFile)
+    ZipFile(jarFile).use { zipFile ->
+        ZipOutputStream(tempFile.outputStream().buffered()).use { zipOutput ->
+            val entries = zipFile.entries()
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                val newEntry = ZipEntry(entry.name)
+                zipOutput.putNextEntry(newEntry)
+
+                if (!entry.isDirectory) {
+                    val bytes = zipFile.getInputStream(entry).use { input ->
+                        input.readBytes()
+                    }
+
+                    if (entry.name in classEntries) {
+                        val classReader = ClassReader(bytes)
+                        val classWriter = ClassWriter(0)
+                        val classVisitor = object : ClassVisitor(Opcodes.ASM9, classWriter) {
+                            override fun visit(
+                                version: Int,
+                                access: Int,
+                                name: String?,
+                                signature: String?,
+                                superName: String?,
+                                interfaces: Array<out String>?
+                            ) {
+                                super.visit(targetVersion, access, name, signature, superName, interfaces)
+                            }
+                        }
+
+                        classReader.accept(classVisitor, 0)
+                        zipOutput.write(classWriter.toByteArray())
+                    } else {
+                        zipOutput.write(bytes)
+                    }
+                }
+
+                zipOutput.closeEntry()
+            }
+        }
+    }
+
+    tempFile.copyTo(jarFile, overwrite = true)
+    tempFile.delete()
 }

--- a/minevnlib-plugin/build.gradle.kts
+++ b/minevnlib-plugin/build.gradle.kts
@@ -1,28 +1,11 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.gradle.api.GradleException
-import org.objectweb.asm.ClassReader
-import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.Opcodes
-import java.io.File
-import java.util.zip.ZipEntry
-import java.util.zip.ZipFile
-import java.util.zip.ZipOutputStream
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("org.ow2.asm:asm:9.9.1")
-    }
-}
 
 plugins {
     id("com.gradleup.shadow") version "9.4.1"
     id("maven-publish")
 }
+
+apply(from = "rewrite.gradle.kts")
 
 repositories {
 }
@@ -81,17 +64,6 @@ tasks {
         relocate("com.cronutils", "net.minevn.libs.cronutils")
         exclude("META-INF/versions/21/org/h2/util/Utils21.class")
         exclude("META-INF/*.RSA", "META-INF/*.DSA", "META-INF/*.SF")
-
-        doLast {
-            rewriteClassVersion(
-                archiveFile.get().asFile,
-                setOf(
-                    "net/minevn/libs/anvilgui/version/Wrapper26_R1.class",
-                    $$"net/minevn/libs/anvilgui/version/Wrapper26_R1$AnvilContainer.class"
-                ),
-                Opcodes.V17
-            )
-        }
     }
 
     // shadow with kotlin
@@ -130,64 +102,5 @@ tasks {
 
     assemble {
         dependsOn(shadowJar, shadowNoKotlin, customCopy)
-    }
-}
-
-fun rewriteClassVersion(jarFile: File, classEntries: Set<String>, targetVersion: Int) {
-    val tempFile = File.createTempFile(jarFile.nameWithoutExtension, ".jar", jarFile.parentFile)
-    val rewrittenEntries = mutableSetOf<String>()
-    try {
-        ZipFile(jarFile).use { zipFile ->
-            ZipOutputStream(tempFile.outputStream().buffered()).use { zipOutput ->
-                val entries = zipFile.entries()
-                while (entries.hasMoreElements()) {
-                    val entry = entries.nextElement()
-                    val newEntry = ZipEntry(entry.name)
-                    zipOutput.putNextEntry(newEntry)
-
-                    if (!entry.isDirectory) {
-                        val bytes = zipFile.getInputStream(entry).use { input ->
-                            input.readBytes()
-                        }
-
-                        if (entry.name in classEntries) {
-                            val classReader = ClassReader(bytes)
-                            val classWriter = ClassWriter(0)
-                            val classVisitor = object : ClassVisitor(Opcodes.ASM9, classWriter) {
-                                override fun visit(
-                                    version: Int,
-                                    access: Int,
-                                    name: String?,
-                                    signature: String?,
-                                    superName: String?,
-                                    interfaces: Array<out String>?
-                                ) {
-                                    super.visit(targetVersion, access, name, signature, superName, interfaces)
-                                }
-                            }
-
-                            classReader.accept(classVisitor, 0)
-                            zipOutput.write(classWriter.toByteArray())
-                            rewrittenEntries.add(entry.name)
-                        } else {
-                            zipOutput.write(bytes)
-                        }
-                    }
-
-                    zipOutput.closeEntry()
-                }
-            }
-        }
-
-        val missingEntries = classEntries - rewrittenEntries
-        if (missingEntries.isNotEmpty()) {
-            throw GradleException(
-                "Failed to rewrite class version in ${jarFile.name}. Missing entries: ${missingEntries.joinToString()}"
-            )
-        }
-
-        tempFile.copyTo(jarFile, overwrite = true)
-    } finally {
-        tempFile.delete()
     }
 }

--- a/minevnlib-plugin/build.gradle.kts
+++ b/minevnlib-plugin/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.GradleException
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.ClassWriter
@@ -134,47 +135,59 @@ tasks {
 
 fun rewriteClassVersion(jarFile: File, classEntries: Set<String>, targetVersion: Int) {
     val tempFile = File.createTempFile(jarFile.nameWithoutExtension, ".jar", jarFile.parentFile)
-    ZipFile(jarFile).use { zipFile ->
-        ZipOutputStream(tempFile.outputStream().buffered()).use { zipOutput ->
-            val entries = zipFile.entries()
-            while (entries.hasMoreElements()) {
-                val entry = entries.nextElement()
-                val newEntry = ZipEntry(entry.name)
-                zipOutput.putNextEntry(newEntry)
+    val rewrittenEntries = mutableSetOf<String>()
+    try {
+        ZipFile(jarFile).use { zipFile ->
+            ZipOutputStream(tempFile.outputStream().buffered()).use { zipOutput ->
+                val entries = zipFile.entries()
+                while (entries.hasMoreElements()) {
+                    val entry = entries.nextElement()
+                    val newEntry = ZipEntry(entry.name)
+                    zipOutput.putNextEntry(newEntry)
 
-                if (!entry.isDirectory) {
-                    val bytes = zipFile.getInputStream(entry).use { input ->
-                        input.readBytes()
-                    }
-
-                    if (entry.name in classEntries) {
-                        val classReader = ClassReader(bytes)
-                        val classWriter = ClassWriter(0)
-                        val classVisitor = object : ClassVisitor(Opcodes.ASM9, classWriter) {
-                            override fun visit(
-                                version: Int,
-                                access: Int,
-                                name: String?,
-                                signature: String?,
-                                superName: String?,
-                                interfaces: Array<out String>?
-                            ) {
-                                super.visit(targetVersion, access, name, signature, superName, interfaces)
-                            }
+                    if (!entry.isDirectory) {
+                        val bytes = zipFile.getInputStream(entry).use { input ->
+                            input.readBytes()
                         }
 
-                        classReader.accept(classVisitor, 0)
-                        zipOutput.write(classWriter.toByteArray())
-                    } else {
-                        zipOutput.write(bytes)
-                    }
-                }
+                        if (entry.name in classEntries) {
+                            val classReader = ClassReader(bytes)
+                            val classWriter = ClassWriter(0)
+                            val classVisitor = object : ClassVisitor(Opcodes.ASM9, classWriter) {
+                                override fun visit(
+                                    version: Int,
+                                    access: Int,
+                                    name: String?,
+                                    signature: String?,
+                                    superName: String?,
+                                    interfaces: Array<out String>?
+                                ) {
+                                    super.visit(targetVersion, access, name, signature, superName, interfaces)
+                                }
+                            }
 
-                zipOutput.closeEntry()
+                            classReader.accept(classVisitor, 0)
+                            zipOutput.write(classWriter.toByteArray())
+                            rewrittenEntries.add(entry.name)
+                        } else {
+                            zipOutput.write(bytes)
+                        }
+                    }
+
+                    zipOutput.closeEntry()
+                }
             }
         }
-    }
 
-    tempFile.copyTo(jarFile, overwrite = true)
-    tempFile.delete()
+        val missingEntries = classEntries - rewrittenEntries
+        if (missingEntries.isNotEmpty()) {
+            throw GradleException(
+                "Failed to rewrite class version in ${jarFile.name}. Missing entries: ${missingEntries.joinToString()}"
+            )
+        }
+
+        tempFile.copyTo(jarFile, overwrite = true)
+    } finally {
+        tempFile.delete()
+    }
 }

--- a/minevnlib-plugin/rewrite.gradle.kts
+++ b/minevnlib-plugin/rewrite.gradle.kts
@@ -1,0 +1,98 @@
+import org.gradle.api.GradleException
+import org.gradle.jvm.tasks.Jar
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("org.ow2.asm:asm:9.9.1")
+    }
+}
+
+val shadowJarTaskNames = setOf("shadowJar", "shadowNoKotlin")
+val anvilGuiWrapperClassEntries = setOf(
+    "net/minevn/libs/anvilgui/version/Wrapper26_R1.class",
+    $$"net/minevn/libs/anvilgui/version/Wrapper26_R1$AnvilContainer.class"
+)
+
+tasks.withType<Jar>()
+    .matching { task -> task.name in shadowJarTaskNames }
+    .configureEach {
+        doLast {
+            rewriteClassVersion(
+                archiveFile.get().asFile,
+                anvilGuiWrapperClassEntries,
+                Opcodes.V17
+            )
+        }
+    }
+
+fun rewriteClassVersion(jarFile: File, classEntries: Set<String>, targetVersion: Int) {
+    val tempFile = File.createTempFile(jarFile.nameWithoutExtension, ".jar", jarFile.parentFile)
+    val rewrittenEntries = mutableSetOf<String>()
+    try {
+        ZipFile(jarFile).use { zipFile ->
+            ZipOutputStream(tempFile.outputStream().buffered()).use { zipOutput ->
+                val entries = zipFile.entries()
+                while (entries.hasMoreElements()) {
+                    val entry = entries.nextElement()
+                    val newEntry = ZipEntry(entry.name)
+                    zipOutput.putNextEntry(newEntry)
+
+                    if (!entry.isDirectory) {
+                        val bytes = zipFile.getInputStream(entry).use { input ->
+                            input.readBytes()
+                        }
+
+                        if (entry.name in classEntries) {
+                            val classReader = ClassReader(bytes)
+                            val classWriter = ClassWriter(0)
+                            val classVisitor = object : ClassVisitor(Opcodes.ASM9, classWriter) {
+                                override fun visit(
+                                    version: Int,
+                                    access: Int,
+                                    name: String?,
+                                    signature: String?,
+                                    superName: String?,
+                                    interfaces: Array<out String>?
+                                ) {
+                                    super.visit(targetVersion, access, name, signature, superName, interfaces)
+                                }
+                            }
+
+                            classReader.accept(classVisitor, 0)
+                            zipOutput.write(classWriter.toByteArray())
+                            rewrittenEntries.add(entry.name)
+                        } else {
+                            zipOutput.write(bytes)
+                        }
+                    }
+
+                    zipOutput.closeEntry()
+                }
+            }
+        }
+
+        val missingEntries = classEntries - rewrittenEntries
+        if (missingEntries.isNotEmpty()) {
+            throw GradleException(
+                "Failed to rewrite class version in ${jarFile.name}. Missing entries: ${missingEntries.joinToString()}"
+            )
+        }
+
+        tempFile.copyTo(jarFile, overwrite = true)
+        println("file $jarFile rewritten with class version $targetVersion")
+    } finally {
+        tempFile.delete()
+    }
+}


### PR DESCRIPTION
Thư viện AnvilGUI được compile ở Java 25 để hỗ trợ cho Minecraft 26, tuy nhiên Paper <1.21.11 vẫn sử dụng thư viện ASM 9.7 chưa hỗ trợ đọc byte code Java 25 dẫn đến [remapping fail](https://pastes.dev/fmRhjRMzUm). Paper đã [bump](https://github.com/PaperMC/Paper/pull/13743) ASM từ 1.21.11, từ phiên bản này trở đi minevn-library hoạt động bình thường.

PR này thêm 1 bước rewrite class version của Wrapper26_R1 về Java 17 sử dụng ASM, giúp plugin hoạt động tốt trên các phiên bản <1.21.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of packaged plugin classes with newer Java versions by ensuring targeted wrapper bytecode is rewritten during the build.
  * Strengthened build outputs by adding a post-processing step for affected jar artifacts and validating that all expected classes were updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->