### PR TITLE
Fix mở GUI trên CanvasMC

### DIFF
--- a/minevnlib-bukkit/src/main/java/net/minevn/guiapi/ConfiguredUI.kt
+++ b/minevnlib-bukkit/src/main/java/net/minevn/guiapi/ConfiguredUI.kt
@@ -1,6 +1,7 @@
 package net.minevn.guiapi
 
 import net.minevn.libs.bukkit.color
+import net.minevn.libs.bukkit.FoliaUtils
 import net.minevn.libs.bukkit.runSync
 import org.bukkit.configuration.file.YamlConfiguration
 import org.bukkit.entity.Player
@@ -41,5 +42,12 @@ abstract class ConfiguredUI(
 
     fun getConfig() = getConfig(configPath, plugin)
 
-    fun open() = runSync { viewer?.openInventory(inventory) }
+    fun open() {
+        val player = viewer ?: return
+        if (FoliaUtils.isFolia()) {
+            FoliaUtils.runAtEntity(plugin, player) { player.openInventory(inventory) }
+        } else {
+            runSync { player.openInventory(inventory) }
+        }
+    }
 }

--- a/minevnlib-bukkit/src/main/java/net/minevn/libs/bukkit/FoliaUtils.kt
+++ b/minevnlib-bukkit/src/main/java/net/minevn/libs/bukkit/FoliaUtils.kt
@@ -1,9 +1,11 @@
 package net.minevn.libs.bukkit
 
 import org.bukkit.Bukkit
+import org.bukkit.entity.Entity
 import org.bukkit.plugin.Plugin
 import org.bukkit.plugin.java.JavaPlugin
 import org.bukkit.scheduler.BukkitTask
+import java.util.function.Consumer
 import java.util.concurrent.TimeUnit
 
 object FoliaUtils {
@@ -103,6 +105,39 @@ object FoliaUtils {
                 override fun isCancelled(): Boolean = false
                 override fun getOwner(): Plugin = plugin
                 override fun cancel() {
+                    val method = task.javaClass.getMethod("cancel")
+                    method.isAccessible = true
+                    method.invoke(task)
+                }
+            }
+        } else {
+            Bukkit.getScheduler().runTask(plugin, runnable)
+        }
+    }
+
+    /**
+     * Run a task on the entity's owning region scheduler
+     */
+    @JvmStatic
+    fun runAtEntity(plugin: JavaPlugin, entity: Entity, runnable: Runnable): BukkitTask {
+        return if (isFolia()) {
+            val scheduler = entity.javaClass.getMethod("getScheduler").invoke(entity)
+            val method = scheduler.javaClass.getMethod(
+                "run",
+                Plugin::class.java,
+                Consumer::class.java,
+                Runnable::class.java
+            )
+            val task = method.invoke(scheduler, plugin, Consumer<Any> { runnable.run() }, null)
+            object : BukkitTask {
+                override fun getTaskId(): Int = -1
+                override fun isSync(): Boolean = true
+                override fun isCancelled(): Boolean = false
+                override fun getOwner(): Plugin = plugin
+                override fun cancel() {
+                    if (task == null) {
+                        return
+                    }
                     val method = task.javaClass.getMethod("cancel")
                     method.isAccessible = true
                     method.invoke(task)


### PR DESCRIPTION
- Thêm FoliaUtils.runAtEntity để schedule task theo owning region scheduler của entity trên Folia/Canvas
- Đổi ConfiguredUI.open() sang chạy openInventory trên scheduler của player thay vì GlobalRegionScheduler khi server là Folia
- CanvasMC: [TickGuard](https://github.com/CraftCanvasMC/Canvas/blob/pre-merger/26.2/canvas-server/src/main/java/io/canvasmc/canvas/util/TickGuard.java) chặn ServerPlayer.initMenu nếu openInventory chạy trên global region thread, vì menu của player phải chạy đúng tick thread của entity

```
[20:25:03 WARN]: [MineVNLib] Global task for MineVNLib v26.1.1 generated an exception
java.lang.IllegalStateException: Thread failed main thread check: Cannot init menu async, context=[thread=Folia Region Scheduler Thread #0,class=io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner,region={null}], entity={root=[{type=ServerPlayer,id=473,uuid=602b734d-72f2-4ab7-81ab-a287e0e9e999,pos=(660.882,150.919,-914.101),mot=(0.000,0.000,0.000),aabb=AABB[660.5819193147515, 150.9189493122412, -914.4008992758181] -> [661.1819193385934, 152.7189492645575, -913.8008992519763],removed=null,has_vehicle=false,passenger_count=0], vehicle=[{null}], passengers=[]
        at ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(TickThread.java:98) ~[canvas-26.1.2.jar:26.1.2-836-1a0c49d]
        at io.canvasmc.canvas.util.TickGuard.guard(TickGuard.java:51) ~[canvas-26.1.2.jar:26.1.2-836-1a0c49d]
        at net.minecraft.server.level.ServerPlayer.initMenu(ServerPlayer.java:921) ~[canvas-26.1.2.jar:26.1.2-836-1a0c49d]
        at org.bukkit.craftbukkit.entity.CraftHumanEntity.openCustomInventory(CraftHumanEntity.java:390) ~[canvas-26.1.2.jar:26.1.2-836-1a0c49d]
        at org.bukkit.craftbukkit.entity.CraftHumanEntity.openInventory(CraftHumanEntity.java:361) ~[canvas-26.1.2.jar:26.1.2-836-1a0c49d]
        at MineVNLib.jar//net.minevn.guiapi.ConfiguredUI.open$lambda$0(ConfiguredUI.kt:44) ~[?:?]
        at MineVNLib.jar//net.minevn.libs.bukkit.FoliaUtils.runGlobal$lambda$0(FoliaUtils.kt:99) ~[?:?]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI opening behavior on Folia servers to use the correct entity-aware scheduling path.
  * Added a safer fallback for non-Folia servers, helping inventory screens open more reliably across server types.
  * Prevented attempts to open a UI when no viewer is available, reducing avoidable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->